### PR TITLE
Respond to `props.opts` changes

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -140,13 +140,11 @@ class YouTube extends React.Component {
   }
 
   destroyPlayer() {
-    this._internalPlayer.destroy();
-    delete this._internalPlayer;
+    return this._internalPlayer.destroy();
   }
 
   resetPlayer() {
-    this.destroyPlayer();
-    this.createPlayer();
+    this.destroyPlayer().then(this.createPlayer);
   }
 
   updateVideo() {

--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -60,14 +60,20 @@ class YouTube extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    // check if url is changed and update is needed
-    if (prevProps.url !== this.props.url) {
+    const urlHasChanged = prevProps.url !== this.props.url;
+    const optsHaveChanged = !(_.isEqual(prevProps.opts, this.props.opts));
+
+    if (optsHaveChanged) {
+      return this.resetPlayer();
+    }
+
+    if (urlHasChanged) {
       this.updateVideo();
     }
   }
 
   componentWillUnmount() {
-    this._internalPlayer.destroy();
+    this.destroyPlayer();
   }
 
   /**
@@ -131,6 +137,16 @@ class YouTube extends React.Component {
     this._internalPlayer.on('stateChange', ::this.onPlayerStateChange);
     // update video
     this.updateVideo();
+  }
+
+  destroyPlayer() {
+    this._internalPlayer.destroy();
+    delete this._internalPlayer;
+  }
+
+  resetPlayer() {
+    this.destroyPlayer();
+    this.createPlayer();
   }
 
   updateVideo() {

--- a/test/YouTube-test.js
+++ b/test/YouTube-test.js
@@ -30,6 +30,86 @@ describe('YouTube', () => {
     expect(playerMock.on.calls.length).toBe(3);
   });
 
+  it('should create and bind a new youtube player when props.opts changes', () => {
+    const { playerMock, rerender } = fullRender({
+      url: 'https://www.youtube.com/watch?v=XxVg_s8xAms',
+      opts: {
+        width: '480px',
+        height: '360px',
+        playerVars: {
+          autoplay: 1,
+        },
+      },
+    });
+
+    rerender({
+      url: 'https://www.youtube.com/watch?v=XxVg_s8xAms',
+      opts: {
+        width: '480px',
+        height: '360px',
+        playerVars: {
+          autoplay: 0, // changed
+        },
+      },
+    });
+
+    // player is destroyed & rebound
+    expect(playerMock.destroy).toHaveBeenCalled();
+  });
+
+  it('should NOT create and bind a new youtube player when props.url changes', () => {
+    const { playerMock, rerender } = fullRender({
+      url: 'https://www.youtube.com/watch?v=XxVg_s8xAms',
+      opts: {
+        width: '480px',
+        height: '360px',
+        playerVars: {
+          autoplay: 1,
+        },
+      },
+    });
+
+    rerender({
+      url: 'https://www.youtube.com/watch?v=-DX3vJiqxm4', // changed
+      opts: {
+        width: '480px',
+        height: '360px',
+        playerVars: {
+          autoplay: 1,
+        },
+      },
+    });
+
+    expect(playerMock.destroy).toNotHaveBeenCalled();
+  });
+
+  it('should create and bind a new youtube player when props.opts AND props.url changes', () => {
+    const { playerMock, rerender } = fullRender({
+      url: 'https://www.youtube.com/watch?v=XxVg_s8xAms',
+      opts: {
+        width: '480px',
+        height: '360px',
+        playerVars: {
+          autoplay: 1,
+        },
+      },
+    });
+
+    rerender({
+      url: 'https://www.youtube.com/watch?v=-DX3vJiqxm4', // changed
+      opts: {
+        width: '480px',
+        height: '360px',
+        playerVars: {
+          autoplay: 0, // changed
+        },
+      },
+    });
+
+    // player is destroyed & rebound
+    expect(playerMock.destroy).toHaveBeenCalled();
+  });
+
   it('should load a url', () => {
     const { playerMock } = fullRender({
       url: 'https://www.youtube.com/watch?v=XxVg_s8xAms',

--- a/test/helpers/setupYouTube.js
+++ b/test/helpers/setupYouTube.js
@@ -8,15 +8,17 @@ import proxyquire from 'proxyquire';
 /**
  * Create & provide access to a mocked youtube player used inside `YouTube`
  *
+ * Calling a function returns a promise, see: https://github.com/gajus/youtube-player/blob/59ea18f044401f3b9ca282f47224f967a8df4712/src/index.js#L48
+ *
  * @returns {Object}
  */
 
 const setupYouTube = () => {
   const playerMock = {
-    on: expect.createSpy(),
-    cueVideoById: expect.createSpy(),
-    loadVideoById: expect.createSpy(),
-    destroy: expect.createSpy(),
+    on: expect.createSpy().andReturn(Promise.resolve()),
+    cueVideoById: expect.createSpy().andReturn(Promise.resolve()),
+    loadVideoById: expect.createSpy().andReturn(Promise.resolve()),
+    destroy: expect.createSpy().andReturn(Promise.resolve()),
   };
 
   const YouTube = proxyquire('../../src/YouTube', {


### PR DESCRIPTION
When `props.opts` changes, the current `_internalPlayer` is destroyed &
recreated with the new options.