### PR TITLE
import isEqual and uniqueId as individual functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/compedit/react-youtube",
   "dependencies": {
-    "underscore": "^1.8.3",
+    "lodash": "3.x",
     "youtube-player": "^2.0.0"
   },
   "devDependencies": {

--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -3,7 +3,8 @@
  */
 
 import React from 'react';
-import _ from 'underscore';
+import uniqueId from 'lodash/utility/uniqueId';
+import isEqual from 'lodash/lang/isEqual';
 import youTubePlayer from 'youtube-player';
 
 /**
@@ -49,7 +50,7 @@ class YouTube extends React.Component {
   constructor(props) {
     super(props);
 
-    this._containerId = props.id || _.uniqueId('player_');
+    this._containerId = props.id || uniqueId('player_');
     this._internalPlayer = null;
   }
 
@@ -58,7 +59,7 @@ class YouTube extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const optsHaveChanged = !(_.isEqual(prevProps.opts, this.props.opts));
+    const optsHaveChanged = !(isEqual(prevProps.opts, this.props.opts));
     const videoHasChanged = prevProps.videoId !== this.props.videoId;
 
     if (optsHaveChanged) {


### PR DESCRIPTION
This avoids including the entirety of Underscore (~6kb min+gzip) in
users' browserified/webpacked app builds. Instead, it only includes
the two necessary Lodash functions. (Lodash functions, because
Underscore doesn't publish functions as individual files, so they
can't be imported one by one.)

The lodash versions of these functions are compatible with the
Underscore versions, so there shouldn't be any trouble there :)