### PR TITLE
fix un-bound createPlayer method call

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -143,7 +143,7 @@ class YouTube extends React.Component {
   }
 
   resetPlayer() {
-    this.destroyPlayer().then(this.createPlayer);
+    this.destroyPlayer().then(::this.createPlayer);
   }
 
   updateVideo() {


### PR DESCRIPTION
Otherwise `this` might be `null` inside the createPlayer() method.
Fixes a "Cannot read property `_containerId` of undefined" error.

I'm not entirely sure how to test this change—it doesn't seem to
actually happen in the tests, but it does happen in-browser, for
me, at least.