### PR TITLE
Fix for server-side rendering

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -128,6 +128,8 @@ class YouTube extends React.Component {
   }
 
   createPlayer() {
+    // do not attempt to create a player server-side, it won't work
+    if (typeof document === 'undefined') return;
     // create player
     this._internalPlayer = youTubePlayer(this._containerId, { ...this.props.opts });
     // attach event handlers


### PR DESCRIPTION
See #57 
:warning: Untested
I first need the updated youtube-player to be able to test this change because at the moment just importing youtube-player triggers an error server-side.
Doing so manually would be a pain (and potentially cause more issues) so I'll wait for @troybetz to update the package on npm...

EDIT: I messed up and had to recreate the pull request, sorry for that...