### PR TITLE
Preload video if props.videoId is given

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -131,13 +131,16 @@ class YouTube extends React.Component {
     // do not attempt to create a player server-side, it won't work
     if (typeof document === 'undefined') return;
     // create player
-    this._internalPlayer = youTubePlayer(this._containerId, { ...this.props.opts });
+    const playerOpts = {
+      ...this.props.opts,
+      // preload the `videoId` video if one is already given
+      videoId: this.props.videoId
+    };
+    this._internalPlayer = youTubePlayer(this._containerId, playerOpts);
     // attach event handlers
     this._internalPlayer.on('ready', ::this.onPlayerReady);
     this._internalPlayer.on('error', ::this.onPlayerError);
     this._internalPlayer.on('stateChange', ::this.onPlayerStateChange);
-    // update video
-    this.updateVideo();
   }
 
   destroyPlayer() {

--- a/test/YouTube-test.js
+++ b/test/YouTube-test.js
@@ -112,14 +112,16 @@ describe('YouTube', () => {
 
   it('should load a video', () => {
     const { playerMock } = fullRender({
+      id: 'should-load-a-video',
       videoId: 'XxVg_s8xAms',
     });
 
-    expect(playerMock.cueVideoById).toHaveBeenCalledWith({ videoId: 'XxVg_s8xAms' });
+    expect(playerMock).toHaveBeenCalledWith('should-load-a-video', { videoId: 'XxVg_s8xAms' });
   });
 
   it('should load a new video', () => {
     const { playerMock, rerender } = fullRender({
+      id: 'new-video',
       videoId: 'XxVg_s8xAms',
     });
 
@@ -127,12 +129,13 @@ describe('YouTube', () => {
       videoId: '-DX3vJiqxm4',
     });
 
-    expect(playerMock.cueVideoById).toHaveBeenCalledWith({ videoId: 'XxVg_s8xAms' });
+    expect(playerMock).toHaveBeenCalledWith('new-video', { videoId: 'XxVg_s8xAms' });
     expect(playerMock.cueVideoById).toHaveBeenCalledWith({ videoId: '-DX3vJiqxm4' });
   });
 
   it('should load a video with autoplay enabled', () => {
     const { playerMock } = fullRender({
+      id: 'should-load-autoplay',
       videoId: 'XxVg_s8xAms',
       opts: {
         playerVars: {
@@ -142,11 +145,44 @@ describe('YouTube', () => {
     });
 
     expect(playerMock.cueVideoById).toNotHaveBeenCalled();
-    expect(playerMock.loadVideoById).toHaveBeenCalledWith({ videoId: 'XxVg_s8xAms' });
+    expect(playerMock.loadVideoById).toNotHaveBeenCalled();
+    expect(playerMock).toHaveBeenCalledWith('should-load-autoplay', {
+      videoId: 'XxVg_s8xAms',
+      playerVars: {
+        autoplay: 1,
+      },
+    });
+  });
+
+  it('should load a new video with autoplay enabled', () => {
+    const { playerMock, rerender } = fullRender({
+      id: 'should-load-new-autoplay',
+      videoId: 'XxVg_s8xAms',
+      opts: {
+        playerVars: {
+          autoplay: 1,
+        },
+      },
+    });
+
+    expect(playerMock).toHaveBeenCalledWith('should-load-new-autoplay', {
+      videoId: 'XxVg_s8xAms',
+      playerVars: {
+        autoplay: 1,
+      },
+    });
+
+    rerender({
+      videoId: 'something'
+    });
+
+    expect(playerMock.cueVideoById).toNotHaveBeenCalled();
+    expect(playerMock.loadVideoById).toHaveBeenCalledWith({ videoId: 'something' });
   });
 
   it('should load a video with a set starting and ending time', () => {
-    const { playerMock } = fullRender({
+    const { playerMock, rerender } = fullRender({
+      id: 'start-and-end',
       videoId: 'XxVg_s8xAms',
       opts: {
         playerVars: {
@@ -156,7 +192,23 @@ describe('YouTube', () => {
       },
     });
 
-    expect(playerMock.cueVideoById).toHaveBeenCalledWith({ videoId: 'XxVg_s8xAms', startSeconds: 1, endSeconds: 2 });
+    expect(playerMock).toHaveBeenCalledWith('start-and-end', {
+      videoId: 'XxVg_s8xAms',
+      playerVars: {
+        start: 1,
+        end: 2,
+      },
+    });
+
+    rerender({
+      videoId: 'KYzlpRvWZ6c'
+    });
+
+    expect(playerMock.cueVideoById).toHaveBeenCalledWith({
+      videoId: 'KYzlpRvWZ6c',
+      startSeconds: 1,
+      endSeconds: 2
+    });
   });
 
   it('should destroy the youtube player', () => {

--- a/test/helpers/setupYouTube.js
+++ b/test/helpers/setupYouTube.js
@@ -2,6 +2,7 @@
  * Module dependencies
  */
 
+import assign from 'lodash/assign';
 import expect from 'expect';
 import proxyquire from 'proxyquire';
 
@@ -14,15 +15,20 @@ import proxyquire from 'proxyquire';
  */
 
 const setupYouTube = () => {
-  const playerMock = {
+  const playerMethods = {
     on: expect.createSpy().andReturn(Promise.resolve()),
     cueVideoById: expect.createSpy().andReturn(Promise.resolve()),
     loadVideoById: expect.createSpy().andReturn(Promise.resolve()),
     destroy: expect.createSpy().andReturn(Promise.resolve()),
   };
+  const playerMock = expect.createSpy().andReturn(playerMethods);
+
+  // Add the mocked methods to the playerMock object too, so they can be
+  // accessed easily by tests.
+  assign(playerMock, playerMethods);
 
   const YouTube = proxyquire('../../src/YouTube', {
-    'youtube-player': () => playerMock,
+    'youtube-player': playerMock,
   }).default;
 
   return {


### PR DESCRIPTION
This patch speeds up loading the first video that's played with a
react-youtube instance. Previously, the YT player would be created
and had to be loaded completely before a video was loaded in using
cueVideoById or loadVideoById. With this patch, the YouTube API
creates an iframe with the video details already in it, allowing it to
start playing the video one or two seconds earlier.

To illustrate the difference, an example iframe src URL before the
patch:

    https://www.youtube.com/embed/?autoplay=1&...

and after the patch:

    https://www.youtube.com/embed/2gWIjRqvtnI?autoplay=1&...

When a new video is loaded later because of a change in
`props.videoId`, that video will just play in the same iframe too,
so that stays just as speedy as it was before.

Things like `startSeconds` and `autoplay` also still work with
this patch :smile: