### PR TITLE
Allow passing videoId == null to keep a player around without playing video

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -70,7 +70,7 @@ function shouldResetPlayer(prevProps, props) {
 
 class YouTube extends React.Component {
   static propTypes = {
-    videoId: React.PropTypes.string.isRequired,
+    videoId: React.PropTypes.string,
 
     // custom ID for player element
     id: React.PropTypes.string,
@@ -206,6 +206,11 @@ class YouTube extends React.Component {
   }
 
   updateVideo() {
+    if (typeof this.props.videoId === 'undefined' || this.props.videoId === null) {
+      this._internalPlayer.stopVideo();
+      return;
+    }
+
     // set queueing options
     let autoplay = false;
     const opts = {

--- a/test/YouTube-test.js
+++ b/test/YouTube-test.js
@@ -142,6 +142,28 @@ describe('YouTube', () => {
     expect(playerMock.cueVideoById).toHaveBeenCalledWith({ videoId: '-DX3vJiqxm4' });
   });
 
+  it('should not load a video when props.videoId is null', () => {
+    const { playerMock } = fullRender({
+      videoId: null,
+    });
+
+    expect(playerMock.cueVideoById).toNotHaveBeenCalled();
+  });
+
+  it('should stop a video when props.videoId changes to null', () => {
+    const { playerMock, rerender } = fullRender({
+      videoId: 'XxVg_s8xAms',
+    });
+
+    expect(playerMock).toHaveBeenCalled();
+
+    rerender({
+      videoId: null,
+    });
+
+    expect(playerMock.stopVideo).toHaveBeenCalled();
+  });
+
   it('should load a video with autoplay enabled', () => {
     const { playerMock } = fullRender({
       id: 'should-load-autoplay',
@@ -210,13 +232,13 @@ describe('YouTube', () => {
     });
 
     rerender({
-      videoId: 'KYzlpRvWZ6c'
+      videoId: 'KYzlpRvWZ6c',
     });
 
     expect(playerMock.cueVideoById).toHaveBeenCalledWith({
       videoId: 'KYzlpRvWZ6c',
       startSeconds: 1,
-      endSeconds: 2
+      endSeconds: 2,
     });
   });
 

--- a/test/helpers/setupYouTube.js
+++ b/test/helpers/setupYouTube.js
@@ -19,6 +19,7 @@ const setupYouTube = () => {
     on: expect.createSpy().andReturn(Promise.resolve()),
     cueVideoById: expect.createSpy().andReturn(Promise.resolve()),
     loadVideoById: expect.createSpy().andReturn(Promise.resolve()),
+    stopVideo: expect.createSpy().andReturn(Promise.resolve()),
     destroy: expect.createSpy().andReturn(Promise.resolve()),
   };
   const playerMock = expect.createSpy().andReturn(playerMethods);


### PR DESCRIPTION
Note: this conflicts with #63, so if both PRs are accepted I'll rebase whichever
is merged last.

This patch accepts `videoId={null}` or to omit the `videoId` prop entirely. If
the `videoId` prop is empty, no video will be played, or the playing video will
be stopped.

This allows `react-youtube` to also represent the YouTube API's "stopped" state.
It's useful for cases where you don't know what you're going to play yet, but
where you do want to have the YouTube iframe around. Perhaps to reserve pixels
on the page, or to be able to load videos more quickly once you _do_ know what
to play, or to keep the `iframe` on the page to work around Chrome's [gesture
requirement for media playback](http://techdows.com/2015/08/future-chrome-versions-wont-autoplay-media-in-the-background-tabs.html).