### PR TITLE
Do not reset player when playerVars.{start,end} change

### DIFF
--- a/test/YouTube-test.js
+++ b/test/YouTube-test.js
@@ -38,6 +38,7 @@ describe('YouTube', () => {
         height: '360px',
         playerVars: {
           autoplay: 1,
+          start: 0,
         },
       },
     });
@@ -48,7 +49,8 @@ describe('YouTube', () => {
         width: '480px',
         height: '360px',
         playerVars: {
-          autoplay: 0, // changed
+          autoplay: 0, // changed, forces destroy & rebind
+          start: 10, // changed, but does not destroy & rebind
         },
       },
     });
@@ -57,7 +59,7 @@ describe('YouTube', () => {
     expect(playerMock.destroy).toHaveBeenCalled();
   });
 
-  it('should NOT create and bind a new youtube player when props.videoId changes', () => {
+  it('should NOT create and bind a new youtube player when props.videoId, playerVars.start, or playerVars.end change', () => {
     const { playerMock, rerender } = fullRender({
       videoId: 'XxVg_s8xAms',
       opts: {
@@ -65,6 +67,8 @@ describe('YouTube', () => {
         height: '360px',
         playerVars: {
           autoplay: 1,
+          start: 0,
+          end: 50,
         },
       },
     });
@@ -76,11 +80,16 @@ describe('YouTube', () => {
         height: '360px',
         playerVars: {
           autoplay: 1,
+          start: 10, // changed, does not force destroy & rebind
+          end: 20, // changed, does not force destroy & rebind
         },
       },
     });
 
+    // player is NOT destroyed & rebound, despite the changes
     expect(playerMock.destroy).toNotHaveBeenCalled();
+    // instead only the video is updated
+    expect(playerMock.loadVideoById).toHaveBeenCalled();
   });
 
   it('should create and bind a new youtube player when props.opts AND props.videoId change', () => {


### PR DESCRIPTION
Note: this (also) conflicts with #63, so if both PRs are accepted I'll rebase
whichever is merged last.

A change in the start or end time of a video can be resolved by
calling `updateVideo`, instead of resetting the player. This makes
loading the next video a bit faster if it has a different start or
end time than the previous video. If the next video is loaded when
the user is not on the tab, this also helps deal with Chrome's
[gesture requirement for media playback](http://techdows.com/2015/08/future-chrome-versions-wont-autoplay-media-in-the-background-tabs.html), by reusing the same
YouTube API iframe instead of creating a new one.

Now a player reset is triggered when `props.opts` changes, ignoring
`playerVars.start` and `playerVars.end`. All other `props.opts`
properties still trigger a full reset.

A video update is triggered when `props.videoId` changes, but also
when `playerVars.start` or `playerVars.end` change.

In the common case, `playerVars.{start,end}` will only change when
`props.videoId` changes, and that will now only trigger a video
update instead of a player reset :)

(A future optimisation could be to use YouTube's `seekTo` method if
`playerVars.start` is the only changed property.)