### PR TITLE
babel6 module.exports fix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["es2015", "react", "stage-0"]
+  "presets": ["es2015", "react", "stage-0"],
+  "plugins": [
+    "add-module-exports"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-core": "^6.1.2",
     "babel-eslint": "^4.1.1",
     "babel-loader": "^6.2.0",
+    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.1.2",
     "babel-preset-react": "^6.1.2",
     "babel-preset-stage-0": "^6.1.2",

--- a/test/helpers/setupYouTube.js
+++ b/test/helpers/setupYouTube.js
@@ -30,7 +30,7 @@ const setupYouTube = () => {
 
   const YouTube = proxyquire('../../src/YouTube', {
     'youtube-player': playerMock,
-  }).default;
+  });
 
   return {
     playerMock,


### PR DESCRIPTION
Babel@6 doesn't export default module.exports any more, as that is the case, with Node's require you need to suffix .default on the end, adding the "babel-plugin-add-module-exports" plugin resolves this.

This fixes issues I have been having with mocking the react-youtube module with the webpack inject-loader.
