### PR TITLE
prevent YT API from replacing React nodes, fixes #74

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -3,7 +3,6 @@
  */
 
 import React from 'react';
-import uniqueId from 'lodash/uniqueId';
 import isEqual from 'lodash/isEqual';
 import youTubePlayer from 'youtube-player';
 
@@ -111,7 +110,7 @@ class YouTube extends React.Component {
   constructor(props) {
     super(props);
 
-    this._containerId = props.id || uniqueId('player_');
+    this._container = null;
     this._internalPlayer = null;
   }
 
@@ -216,7 +215,7 @@ class YouTube extends React.Component {
       // preload the `videoId` video if one is already given
       videoId: this.props.videoId,
     };
-    this._internalPlayer = youTubePlayer(this._containerId, playerOpts);
+    this._internalPlayer = youTubePlayer(this._container, playerOpts);
     // attach event handlers
     this._internalPlayer.on('ready', ::this.onPlayerReady);
     this._internalPlayer.on('error', ::this.onPlayerError);
@@ -263,13 +262,19 @@ class YouTube extends React.Component {
     this._internalPlayer.cueVideoById(opts);
   }
 
+  refContainer = (container) => {
+    this._container = container;
+  };
+
   /**
    * @returns Object
    */
 
   render() {
     return (
-      <div id={this._containerId} className={this.props.className} />
+      <span>
+        <div id={this.props.id} className={this.props.className} ref={this.refContainer} />
+      </span>
     );
   }
 }

--- a/test/YouTube-test.js
+++ b/test/YouTube-test.js
@@ -4,23 +4,27 @@ import shallowRender from './helpers/shallowRender';
 import fullRender from './helpers/fullRender';
 
 describe('YouTube', () => {
+  // See helpers/setupEnvironment.
+  const HTMLDivElement = window.HTMLDivElement;
+
   it('should render a div with a custom id', () => {
     const { output } = shallowRender({
       id: 'custom-id',
       videoId: 'XxVg_s8xAms',
     });
 
-    expect(output.props.id).toBe('custom-id');
+    const div = output.props.children;
+    expect(div.props.id).toBe('custom-id');
   });
 
   it('should render a div with a custom className', () => {
     const { output } = shallowRender({
-      id: 'custom-id',
       className: 'custom-class',
       videoId: 'XxVg_s8xAms',
     });
 
-    expect(output.props.className).toBe('custom-class');
+    const div = output.props.children;
+    expect(div.props.className).toBe('custom-class');
   });
 
   it('should create and bind a new youtube player when mounted', () => {
@@ -126,7 +130,8 @@ describe('YouTube', () => {
       videoId: 'XxVg_s8xAms',
     });
 
-    expect(playerMock).toHaveBeenCalledWith('should-load-a-video', { videoId: 'XxVg_s8xAms' });
+    expect(playerMock).toHaveBeenCalled();
+    expect(playerMock.calls[0].arguments[1]).toEqual({ videoId: 'XxVg_s8xAms' });
   });
 
   it('should load a new video', () => {
@@ -139,7 +144,9 @@ describe('YouTube', () => {
       videoId: '-DX3vJiqxm4',
     });
 
-    expect(playerMock).toHaveBeenCalledWith('new-video', { videoId: 'XxVg_s8xAms' });
+    expect(playerMock).toHaveBeenCalled();
+    expect(playerMock.calls[0].arguments[0]).toBeAn(HTMLDivElement);
+    expect(playerMock.calls[0].arguments[1]).toEqual({ videoId: 'XxVg_s8xAms' });
     expect(playerMock.cueVideoById).toHaveBeenCalledWith({ videoId: '-DX3vJiqxm4' });
   });
 
@@ -178,7 +185,8 @@ describe('YouTube', () => {
 
     expect(playerMock.cueVideoById).toNotHaveBeenCalled();
     expect(playerMock.loadVideoById).toNotHaveBeenCalled();
-    expect(playerMock).toHaveBeenCalledWith('should-load-autoplay', {
+    expect(playerMock).toHaveBeenCalled();
+    expect(playerMock.calls[0].arguments[1]).toEqual({
       videoId: 'XxVg_s8xAms',
       playerVars: {
         autoplay: 1,
@@ -197,7 +205,8 @@ describe('YouTube', () => {
       },
     });
 
-    expect(playerMock).toHaveBeenCalledWith('should-load-new-autoplay', {
+    expect(playerMock).toHaveBeenCalled();
+    expect(playerMock.calls[0].arguments[1]).toEqual({
       videoId: 'XxVg_s8xAms',
       playerVars: {
         autoplay: 1,
@@ -214,7 +223,6 @@ describe('YouTube', () => {
 
   it('should load a video with a set starting and ending time', () => {
     const { playerMock, rerender } = fullRender({
-      id: 'start-and-end',
       videoId: 'XxVg_s8xAms',
       opts: {
         playerVars: {
@@ -224,7 +232,8 @@ describe('YouTube', () => {
       },
     });
 
-    expect(playerMock).toHaveBeenCalledWith('start-and-end', {
+    expect(playerMock).toHaveBeenCalled();
+    expect(playerMock.calls[0].arguments[1]).toEqual({
       videoId: 'XxVg_s8xAms',
       playerVars: {
         start: 1,


### PR DESCRIPTION
When React tries to unmount a component, it expects its own DOM
nodes to exist, so it can remove them. However, the YouTube API
_replaces_ the node with the ID you give it. So, when React tries
to unmount a react-youtube component, it tries to remove a DOM node
that was replaced by a different DOM node and no longer exists.

This patch works around that by bypassing React when creating the
element to use for the YouTube player.

This does make two tests fail. I could change the tests, but I'm
not sure if the ID test is also intended to be a public API, or
just to check that the component renders the right thing.