### PR TITLE
Update .npmignore to exclude example

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 dist/__tests__
 src
+example


### PR DESCRIPTION
Because `src` is not included in the package, the example cannot be run. Therefore, it should also be excluded. 