### PR TITLE
Fix error thrown by changing autoplay and videoId at the same time

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -34,8 +34,9 @@ function filterResetOptions(opts) {
     ...opts,
     playerVars: {
       ...opts.playerVars,
+      autoplay: 0,
       start: 0,
-      end: 0,
+      end: 0
     },
   };
 }

--- a/test/YouTube-test.js
+++ b/test/YouTube-test.js
@@ -77,7 +77,7 @@ describe('YouTube', () => {
         width: '480px',
         height: '360px',
         playerVars: {
-          autoplay: 1,
+          controls: 1,
           start: 0,
         },
       },
@@ -89,7 +89,7 @@ describe('YouTube', () => {
         width: '480px',
         height: '360px',
         playerVars: {
-          autoplay: 0, // changed, forces destroy & rebind
+          controls: 0, // changed, forces destroy & rebind
           start: 10, // changed, but does not destroy & rebind
         },
       },
@@ -99,14 +99,14 @@ describe('YouTube', () => {
     expect(playerMock.destroy).toHaveBeenCalled();
   });
 
-  it('should NOT create and bind a new youtube player when props.videoId, playerVars.start, or playerVars.end change', () => {
+  it('should NOT create and bind a new youtube player when props.videoId, playerVars.autoplay, playerVars.start, or playerVars.end change', () => {
     const { playerMock, rerender } = fullRender({
       videoId: 'XxVg_s8xAms',
       opts: {
         width: '480px',
         height: '360px',
         playerVars: {
-          autoplay: 1,
+          autoplay: 0,
           start: 0,
           end: 50,
         },
@@ -119,7 +119,7 @@ describe('YouTube', () => {
         width: '480px',
         height: '360px',
         playerVars: {
-          autoplay: 1,
+          autoplay: 1, // changed, does not force destroy & rebind
           start: 10, // changed, does not force destroy & rebind
           end: 20, // changed, does not force destroy & rebind
         },
@@ -139,7 +139,7 @@ describe('YouTube', () => {
         width: '480px',
         height: '360px',
         playerVars: {
-          autoplay: 1,
+          controls: 1,
         },
       },
     });
@@ -150,7 +150,7 @@ describe('YouTube', () => {
         width: '480px',
         height: '360px',
         playerVars: {
-          autoplay: 0, // changed
+          controls: 0, // changed
         },
       },
     });


### PR DESCRIPTION
Changing the autoplay in playerVars and the videoId at the same time throws an error caused by attempting to set a new videoId to a player that doesn't exist anymore (since changing autoplay causes the destruction and recreation of the player).

The only code difference between the values of autoplay is in the react-youtube component itself and has nothing to do with the YouTube player, so it shouldn't cause it to reset.. 
The difference is in the updateVideo() function, and that is, call _this.internalPlayer.loadVideoById() if autoplay = 1 and call internalPlayer.cueVideoById() if autoplay = 0.


**Example:**
We want to render the first video and start playing it only on user interaction, but all the videos after to autoplay (pretty much what YouTube does). We create a simple component with the render function as follows (for the sake of example simplicity both videoId and autoplay are set as state, normally videoId would be a prop):

```
onEnd() {
    this.setState = {
        autoplay: 1,
        videoId: 'd3fc12f'
}
render() {
    var opts = {
        height: this.props.height || '640',
        width:  this.props.width || '320',

        playerVars: {
            autoplay: this.state.autoplay,
            controls: 2
        }
    };
    return (
            <YouTube
                videoId={this.state.videoid}
                opts={opts}
                onEnd={this._onEnd.bind(this)}
            />
    );
}
```


At the end of the first video, when the callback is called and the second one loads, an error similar to this one is thrown:

> Unhandled rejection TypeError: Cannot read property 'src' of null
>     at X.g.C (https://s.ytimg.com/yts/jsbin/www-widgetapi-vflvZkdiI/www-widgetapi.js:100:85)
>     at Q (https://s.ytimg.com/yts/jsbin/www-widgetapi-vflvZkdiI/www-widgetapi.js:92:99)
>     at X.(anonymous function).getCurrentTime.Jb.(anonymous function) [as loadVideoById] (https://s.ytimg.com/yts/jsbin/www-widgetapi-vflvZkdiI/www-widgetapi.js:133:11)
>     at http://5.100.231.243/frontend/static/main.concat.js:3192:46
> From previous event:
>     at Object.functions.(anonymous function) [as loadVideoById] (http://5.100.231.243/frontend/static/main.concat.js:3191:36)
>     at YouTube._this.updateVideo (http://5.100.231.243/frontend/static/main.concat.js:529:31)
>     at YouTube.componentDidUpdate (http://5.100.231.243/frontend/static/main.concat.js:564:15)
>     at ReactCompositeComponentWrapper.invokeComponentDidUpdateWithTimer (https://npmcdn.com/react@15.3.1/dist/react.js:5950:18)
>     at CallbackQueue.notifyAll (https://npmcdn.com/react@15.3.1/dist/react.js:840:22)
>     at ReactReconcileTransaction.close (https://npmcdn.com/react@15.3.1/dist/react.js:13642:26)
>     at ReactReconcileTransaction.closeAll (https://npmcdn.com/react@15.3.1/dist/react.js:17053:25)
>     at ReactReconcileTransaction.perform (https://npmcdn.com/react@15.3.1/dist/react.js:17000:16)
>     at ReactUpdatesFlushTransaction.perform (https://npmcdn.com/react@15.3.1/dist/react.js:16987:20)
>     at ReactUpdatesFlushTransaction.perform (https://npmcdn.com/react@15.3.1/dist/react.js:14681:38)
>     at Object.flushBatchedUpdates (https://npmcdn.com/react@15.3.1/dist/react.js:14764:19)
>     at ReactDefaultBatchingStrategyTransaction.closeAll (https://npmcdn.com/react@15.3.1/dist/react.js:17053:25)
>     at ReactDefaultBatchingStrategyTransaction.perform (https://npmcdn.com/react@15.3.1/dist/react.js:17000:16)
>     at Object.batchedUpdates (https://npmcdn.com/react@15.3.1/dist/react.js:10324:19)
>     at Object.enqueueUpdate (https://npmcdn.com/react@15.3.1/dist/react.js:14792:22)
>     at enqueueUpdate (https://npmcdn.com/react@15.3.1/dist/react.js:14389:16)
>     at Object.enqueueSetState (https://npmcdn.com/react@15.3.1/dist/react.js:14574:5)
>     at TV.ReactComponent.setState (https://npmcdn.com/react@15.3.1/dist/react.js:5404:16)
>     at TV.goToNextVideo (http://5.100.231.243/frontend/static/main.concat.js:121:19)