### PR TITLE
deps: upgrade youtube-player

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/compedit/react-youtube",
   "dependencies": {
     "lodash.isequal": "^4.4.0",
-    "youtube-player": "^3.0.4"
+    "youtube-player": "^4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
Hi! :wave: A new version of youtube-player is out. The only breaking change is that it now exports on `module.exports` instead of the Babel-ES6-style `exports.default`, so `require('youtube-player')` now works. Either way, react-youtube isn't affected by it.

Not a super important change, but nice to stay up to date :v: