### PR TITLE
updated eslint packages and fixed lodash/assign error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/compedit/react-youtube",
   "dependencies": {
-    "lodash.assign": "^4.2.0",
     "lodash.isequal": "^4.4.0",
     "youtube-player": "^4.0.1"
   },
@@ -41,6 +40,7 @@
     "eslint-plugin-react": "^6.3.0",
     "expect": "^1.20.2",
     "jsdom": "^9.5.0",
+    "lodash.assign": "^4.2.0",
     "mocha": "^3.1.0",
     "npm-run-all": "^4.0.2",
     "proxyquire": "^1.7.10",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/compedit/react-youtube",
   "dependencies": {
+    "lodash.assign": "^4.2.0",
     "lodash.isequal": "^4.4.0",
     "youtube-player": "^4.0.1"
   },
@@ -34,9 +35,9 @@
     "babel-preset-stage-0": "^6.16.0",
     "cross-env": "^3.2.4",
     "eslint": "^3.6.1",
-    "eslint-config-airbnb": "^12.0.0",
+    "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.0.0",
-    "eslint-plugin-jsx-a11y": "^2.2.2",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.3.0",
     "expect": "^1.20.2",
     "jsdom": "^9.5.0",

--- a/test/helpers/setupYouTube.js
+++ b/test/helpers/setupYouTube.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-import assign from 'lodash/assign';
+import assign from 'lodash.assign';
 import expect from 'expect';
 import proxyquire from 'proxyquire';
 


### PR DESCRIPTION
Fixed the test scripts for this package since it would throw an error like this:

` Error: Cannot find module 'lodash/assign'
        at Function.Module._resolveFilename (module.js:470:15)
        at Function.Module._load (module.js:418:25)
        at Module.require (module.js:498:17)
        at require (internal/module.js:20:19)`

when running `npm test`

Also, running `npm install` would cause dev-dependency errors, which were fixed by the updates on the eslint packages.

EDIT: made it more clear.