### PR TITLE
Replace lodash per-method packages with scoped imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/compedit/react-youtube",
   "dependencies": {
-    "lodash.isequal": "^4.4.0",
+    "lodash": "^4.4.0",
     "prop-types": "^15.5.3",
     "youtube-player": "^4.2.3"
   },
@@ -41,7 +41,6 @@
     "eslint-plugin-react": "^6.3.0",
     "expect": "^1.20.2",
     "jsdom": "^9.5.0",
-    "lodash.assign": "^4.2.0",
     "mocha": "^3.1.0",
     "npm-run-all": "^4.0.2",
     "proxyquire": "^1.7.10",

--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react';
-import isEqual from 'lodash.isequal';
+import isEqual from 'lodash/isEqual';
 import youTubePlayer from 'youtube-player';
 
 /**

--- a/test/helpers/setupYouTube.js
+++ b/test/helpers/setupYouTube.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-import assign from 'lodash.assign';
+import assign from 'lodash/assign';
 import expect from 'expect';
 import proxyquire from 'proxyquire';
 


### PR DESCRIPTION
The per-method packages are zero-dependency modules, so they often
include a bunch of extra code compared to importing from lodash/foo. We
can save some bundle size by using these partial includes instead.

Additionally, if I recall correctly, the per-method packages are all
deprecated and no longer updated, so this is the way to go for lodash
moving forward.