### PR TITLE
Updated youtube-player dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "prop-types": "^15.5.3",
-    "youtube-player": "^4.2.3"
+    "youtube-player": "^5.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
Hello, thank you for this very handy component!
I was looking at reducing my bundle size and noticed the `babel-runtime` dependency used by this module. It was removed in 5.3.0 but you’re still using the old version.
I figured I could simply open a PR to bump the version up. It’s a small size win when gzipped but… 🤷‍♂️

All tests are still passing so I guess it’s fine? :)
See https://github.com/gajus/youtube-player/releases
5.0.0:
“Some internal and deprecated methods have been removed from the abstraction. By the looks of it, it doesn’t break anything. Making the breaking change just in case (as it is a risky change).”