### PR TITLE
✨ support containerClassName

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Usage
   videoId={string}                  // defaults -> null
   id={string}                       // defaults -> null
   className={string}                // defaults -> null
+  containerClassName={string}       // defaults -> ''
   opts={obj}                        // defaults -> {}
   onReady={func}                    // defaults -> noop
   onPlay={func}                     // defaults -> noop

--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -79,6 +79,8 @@ class YouTube extends React.Component {
 
     // custom class name for player element
     className: PropTypes.string,
+    // custom class name for player container element
+    containerClassName: PropTypes.string,
 
     // https://developers.google.com/youtube/iframe_api_reference#Loading_a_Video_Player
     opts: PropTypes.object,
@@ -96,6 +98,7 @@ class YouTube extends React.Component {
 
   static defaultProps = {
     opts: {},
+    containerClassName: '',
     onReady: () => {},
     onError: () => {},
     onPlay: () => {},
@@ -297,7 +300,7 @@ class YouTube extends React.Component {
 
   render() {
     return (
-      <span>
+      <span className={this.props.containerClassName}>
         <div id={this.props.id} className={this.props.className} ref={this.refContainer} />
       </span>
     );


### PR DESCRIPTION
### Description
- ✨Support `containerClassName` prop to be passed to the container span element.

### Reason
- It is hard to style the player in some scenarios given that the className is on the iframe and the iframe is wrapped with a span.