### PR TITLE
Add host prop to set host for player frame

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -47,12 +47,13 @@ function filterResetOptions(opts) {
  * The player is reset when the `props.opts` change, except if the only change
  * is in the `start` and `end` playerVars, because a video update can deal with
  * those.
+ * The player is also reset if the host is changed.
  *
  * @param {Object} prevProps
  * @param {Object} props
  */
 function shouldResetPlayer(prevProps, props) {
-  return !isEqual(
+  return (prevProps.host !== props.host) || !isEqual(
     filterResetOptions(prevProps.opts),
     filterResetOptions(props.opts)
   );
@@ -84,6 +85,7 @@ class YouTube extends React.Component {
 
     // https://developers.google.com/youtube/iframe_api_reference#Loading_a_Video_Player
     opts: PropTypes.object,
+    host: PropTypes.string,
 
     // event subscriptions
     onReady: PropTypes.func,
@@ -100,6 +102,7 @@ class YouTube extends React.Component {
     id: null,
     className: null,
     opts: {},
+    host: null,
     containerClassName: '',
     onReady: () => {},
     onError: () => {},
@@ -234,6 +237,7 @@ class YouTube extends React.Component {
       ...this.props.opts,
       // preload the `videoId` video if one is already given
       videoId: this.props.videoId,
+      host: this.props.host,
     };
     this.internalPlayer = youTubePlayer(this.container, playerOpts);
     // attach event handlers

--- a/test/YouTube-test.js
+++ b/test/YouTube-test.js
@@ -166,7 +166,7 @@ describe('YouTube', () => {
     });
 
     expect(playerMock).toHaveBeenCalled();
-    expect(playerMock.calls[0].arguments[1]).toEqual({ videoId: 'XxVg_s8xAms' });
+    expect(playerMock.calls[0].arguments[1]).toEqual({ videoId: 'XxVg_s8xAms', host: null });
   });
 
   it('should load a new video', () => {
@@ -181,7 +181,7 @@ describe('YouTube', () => {
 
     expect(playerMock).toHaveBeenCalled();
     expect(playerMock.calls[0].arguments[0]).toBeAn(HTMLDivElement);
-    expect(playerMock.calls[0].arguments[1]).toEqual({ videoId: 'XxVg_s8xAms' });
+    expect(playerMock.calls[0].arguments[1]).toEqual({ videoId: 'XxVg_s8xAms', host: null });
     expect(playerMock.cueVideoById).toHaveBeenCalledWith({ videoId: '-DX3vJiqxm4' });
   });
 
@@ -196,6 +196,7 @@ describe('YouTube', () => {
   it('should stop a video when props.videoId changes to null', () => {
     const { playerMock, rerender } = fullRender({
       videoId: 'XxVg_s8xAms',
+      host: null,
     });
 
     expect(playerMock).toHaveBeenCalled();
@@ -223,6 +224,7 @@ describe('YouTube', () => {
     expect(playerMock).toHaveBeenCalled();
     expect(playerMock.calls[0].arguments[1]).toEqual({
       videoId: 'XxVg_s8xAms',
+      host: null,
       playerVars: {
         autoplay: 1,
       },
@@ -243,6 +245,7 @@ describe('YouTube', () => {
     expect(playerMock).toHaveBeenCalled();
     expect(playerMock.calls[0].arguments[1]).toEqual({
       videoId: 'XxVg_s8xAms',
+      host: null,
       playerVars: {
         autoplay: 1,
       },
@@ -270,6 +273,7 @@ describe('YouTube', () => {
     expect(playerMock).toHaveBeenCalled();
     expect(playerMock.calls[0].arguments[1]).toEqual({
       videoId: 'XxVg_s8xAms',
+      host: null,
       playerVars: {
         start: 1,
         end: 2,
@@ -285,6 +289,34 @@ describe('YouTube', () => {
       startSeconds: 1,
       endSeconds: 2,
     });
+  });
+
+  it('should load a video with a custom host', () => {
+    const { playerMock } = fullRender({
+      videoId: 'XxVg_s8xAms',
+      host: 'https://www.invalid-youtube-host.com',
+    });
+
+    expect(playerMock).toHaveBeenCalled();
+    expect(playerMock.calls[0].arguments[1]).toEqual({
+      videoId: 'XxVg_s8xAms',
+      host: 'https://www.invalid-youtube-host.com',
+    });
+  })
+
+  it('should create and bind a new youtube player when props.host changes', () => {
+    const { playerMock, rerender } = fullRender({
+      videoId: 'XxVg_s8xAms',
+      host: 'https://invalid-youtube-host.com',
+    });
+
+    rerender({
+      videoId: 'XxVg_s8xAms',
+      host: 'https://youtube.com',
+    });
+
+    // player is destroyed & rebound
+    expect(playerMock.destroy).toHaveBeenCalled();
   });
 
   it('should destroy the youtube player', () => {


### PR DESCRIPTION
Using this prop you can set the host of the player frame to any host you like.
Practical use case: streaming from www.youtube-nocookie.com