### PR TITLE
Use fast-deep-equals in place of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/compedit/react-youtube",
   "dependencies": {
-    "lodash": "^4.17.4",
+    "fast-deep-equal": "^2.0.1",
     "prop-types": "^15.5.3",
     "youtube-player": "^5.5.1"
   },

--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import isEqual from 'lodash/isEqual';
+import isEqual from 'fast-deep-equal';
 import youTubePlayer from 'youtube-player';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,6 +1922,10 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -2841,10 +2845,6 @@ lodash.keys@^3.0.0:
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@^4.17.4:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 longest@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
As it is faster and is smaller in package bundle. My team at work has been put off from using this library because of the dependency on Lodash, which unless webpack is used can be quite large. A smaller and more light-weight library might be more acceptable to more people. It is also faster than the lodash implementation.