### PR TITLE
chore(types): add host property to Options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ export interface PlayerVars {
 export interface Options {
     height?: string;
     width?: string;
+    host?: string;
     playerVars?: PlayerVars;
 }
 


### PR DESCRIPTION
Hello there, as was mentioned in #185 , passing `{ host: "https://www.youtube-nocookie.com" }` into `opts` enables YouTube's enhanced privacy. This PR is just a corresponding update for type definitions.