### PR TITLE
docs: instructions for TypeScript import

### DIFF
--- a/packages/react-youtube/README.md
+++ b/packages/react-youtube/README.md
@@ -33,7 +33,7 @@ pnpm add react-youtube
 ### Typescript (optional)
 
 ```
-npm install -D @types/react-youtube
+npm install -D @types/youtube-player
 # OR
 yarn add -D @types/youtube-player
 ```

--- a/packages/react-youtube/README.md
+++ b/packages/react-youtube/README.md
@@ -33,7 +33,7 @@ pnpm add react-youtube
 ### Typescript (optional)
 
 ```
-npm install -D react-youtube
+npm install -D @types/react-youtube
 # OR
 yarn add -D @types/youtube-player
 ```

--- a/packages/react-youtube/README.md
+++ b/packages/react-youtube/README.md
@@ -36,6 +36,8 @@ pnpm add react-youtube
 npm install -D @types/youtube-player
 # OR
 yarn add -D @types/youtube-player
+# OR
+pnpm add -D @types/youtube-player
 ```
 
 ## Usage

--- a/packages/react-youtube/README.md
+++ b/packages/react-youtube/README.md
@@ -30,7 +30,7 @@ yarn add react-youtube
 pnpm add react-youtube
 ```
 
-### Typescript (optional)
+### TypeScript (optional)
 
 ```
 npm install -D @types/youtube-player

--- a/packages/react-youtube/README.md
+++ b/packages/react-youtube/README.md
@@ -30,6 +30,14 @@ yarn add react-youtube
 pnpm add react-youtube
 ```
 
+### Typescript (optional)
+
+```
+npm install -D react-youtube
+# OR
+yarn add -D @types/youtube-player
+```
+
 ## Usage
 
 ```js


### PR DESCRIPTION
I have code like this

This does not recognize the type of `player` since `react-youtube` depend on `@types/youtube-player`.
So I had to install `@types/youtube-player` dev dependency on my project to get type reference for the `player` object.

I think it does not make sense to add `@types/youtube-player` in dependencies of `react-youtube` so I am adding it as an instruction in README.md.

If you or anyone knows better way solving it. let me know, so that I can iterate on this PR.

OR you can make yours and close mine.

Thanks!


```
import { useState } from "react";
import YouTube, { YouTubePlayer } from "react-youtube";
import "./App.css";

function App() {
  const [player, setPlayer] = useState<YouTubePlayer>();

  return (
    <div className="App">
      <header className="App-header">
        <button
          onClick={() => {
            player?.getCurrentTime();
          }}
        >
          click
        </button>
        <YouTube
          videoId={"rAhXUkk6ppc"}
          opts={{
            width: 500,
            height: 300,
            playerVars: {
              autoplay: 0,
            },
          }}
          className="container"
          onReady={(event) => setPlayer(event.target)}
        />
      </header>
    </div>
  );
}

export default App;


```