### PR TITLE
don't recreate the player for video changes

### DIFF
--- a/packages/react-youtube/src/YouTube.tsx
+++ b/packages/react-youtube/src/YouTube.tsx
@@ -48,9 +48,7 @@ function filterResetOptions(opts: Options = {}) {
  * those.
  */
 function shouldResetPlayer(prevProps: YouTubeProps, props: YouTubeProps) {
-  return (
-    prevProps.videoId !== props.videoId || !isEqual(filterResetOptions(prevProps.opts), filterResetOptions(props.opts))
-  );
+  return !isEqual(filterResetOptions(prevProps.opts), filterResetOptions(props.opts));
 }
 
 /**

--- a/packages/react-youtube/src/Youtube.test.tsx
+++ b/packages/react-youtube/src/Youtube.test.tsx
@@ -148,18 +148,13 @@ describe('YouTube', () => {
     expect(playerMock.destroy).toHaveBeenCalled();
   });
 
-  it('should create and bind a new YouTube player when props.videoId, playerVars.autoplay, playerVars.start, or playerVars.end change', async () => {
+  it('should not create and bind a new YouTube player when only props.videoId changes', async () => {
     const { rerender } = render(
       <YouTube
         videoId="XxVg_s8xAms"
         opts={{
           width: '480px',
           height: '360px',
-          playerVars: {
-            autoplay: 0,
-            start: 0,
-            end: 50,
-          },
         }}
       />,
     );
@@ -170,19 +165,12 @@ describe('YouTube', () => {
         opts={{
           width: '480px',
           height: '360px',
-          playerVars: {
-            autoplay: 1, // changed, does not force destroy & rebind
-            start: 10, // changed, does not force destroy & rebind
-            end: 20, // changed, does not force destroy & rebind
-          },
         }}
       />,
     );
 
-    // player is destroyed & rebound, despite the changes
-    expect(playerMock.destroy).toHaveBeenCalled();
-    // and the video is updated
-    await waitFor(() => expect(playerMock.loadVideoById).toHaveBeenCalled());
+    // player is not destroyed & rebound, despite the change
+    expect(playerMock.destroy).not.toHaveBeenCalled();
   });
 
   it('should not create and bind a new YouTube player when only playerVars.autoplay, playerVars.start, or playerVars.end change', () => {


### PR DESCRIPTION
I am not sure why the player is being reset when the videoId changes. That case is already handled by `shouldUpdateVideo` as far as I can tell. I tested my change in Firefox and Google Chrome and switching the video still works as expected.

The check has been introduced in https://github.com/tjallingt/react-youtube/pull/284 but I did not find any reason for it there.

Without this change the player automatically leaves fullscreen on video changes which is undesirable for me.
Additionally to that, fullscreen can't then be resumed in Google Chrome, because the youtube player believes it is still fullscreened (https://github.com/iyzana/vsync/issues/53).